### PR TITLE
Fix data installation.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,15 +31,16 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.9
 
-include_package_data = True
-package_data = {'' : ['data/*.txt']}
-
 [options]
 packages = miepython
 install_requires = 
     numpy
     matplotlib
     numba
+
+[options.package_data]
+miepython =
+  data/*.txt
 
 [flake8]
 ignore = W503, D212


### PR DESCRIPTION
As per [the setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html), the package_data settings belong in their own section (options.package_data) of setup.cfg instead of in the metadata section. With this change, the data is installed by `python setup.py install`.